### PR TITLE
Add zoom slider and PNG export for Gantt chart

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,3 +1,7 @@
+:root {
+  --day-width: 20px;
+}
+
 body {
   margin: 0;
   font-family: Arial, sans-serif;
@@ -17,6 +21,17 @@ body {
 #header .controls {
   text-align: center;
   margin-bottom: 10px;
+}
+
+#header .controls .zoomControl {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 10px;
+}
+
+#header .controls input[type="range"] {
+  vertical-align: middle;
 }
 
 /* Scroll container */
@@ -50,9 +65,9 @@ body {
 
 /* Uniform day cells */
 .dayCell {
-  min-width: 20px;
-  max-width: 20px;
-  width: 20px;
+  min-width: var(--day-width);
+  max-width: var(--day-width);
+  width: var(--day-width);
   height: 20px;
   line-height: 20px;
   padding: 0;

--- a/index.html
+++ b/index.html
@@ -12,6 +12,12 @@
       Start Date: <input type="date" id="rangeStart">
       End Date: <input type="date" id="rangeEnd">
       <button id="applyRange">Apply</button>
+      <label class="zoomControl">
+        Zoom:
+        <input type="range" id="zoomSlider" min="5" max="60" value="20">
+        <span id="zoomValue">100%</span>
+      </label>
+      <button id="downloadPng" disabled>Download PNG</button>
       <input type="file" id="fileInput" accept=".json">
     </div>
   </div>
@@ -27,6 +33,7 @@
   </div>
   <div id="tooltip"></div>
 
+  <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
   <script src="assets/js/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a zoom slider that uniformly adjusts the width of timeline day cells
- wire a PNG download action using html2canvas with sanitized filenames and progress feedback
- update styling to support the zoom control and CSS variable-based day widths

## Testing
- browser_container.run_playwright_script (Playwright verification of zoom slider and download)


------
https://chatgpt.com/codex/tasks/task_e_68d5eae662848329b94fe03ec99ccbb6